### PR TITLE
[仕様の提案] deferred:processの第二引数について

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -685,7 +685,9 @@ process."
           (condition-case err
               (progn
                 (setq proc
-                      (apply 'start-process proc-name buf-name command args))
+                      (if (null (car args))
+                          (apply 'start-process proc-name buf-name command nil)
+                        (apply 'start-process proc-name buf-name command args)))
                 (set-process-sentinel
                  proc
                  (lambda (proc event)

--- a/test-deferred.el
+++ b/test-deferred.el
@@ -654,7 +654,14 @@
         (buffer-string))
       (wtest 0.1 ;; maybe fail in some environments...
        (deferred:process "pwd")))
-      
+
+     (expect 
+      (with-temp-buffer 
+        (call-process "pwd" nil t nil)
+        (buffer-string))
+      (wtest 0.1 ;; maybe fail in some environments...
+       (deferred:process "pwd" nil)))
+     
      (expect "Searching for program: no such file or directory, pwd---"
              (dtest
               (deferred:process "pwd---")
@@ -663,4 +670,3 @@
 
      ) ;expectations
     ))
-


### PR DESCRIPTION
deferred:process の第二引数にnilを許容するというのはどうでしょうか。
そうすることでラッパー関数が書きやすくなります。ライブラリ利用者が自身のくだらないバグに悩む機会が減ります。http://gist.github.com/617034  でサンプルコードを作成しました。例にあげたwrapper-deferredの他にも、deferred:processに渡すコマンドを組み立てる関数が作成されることは多いのではないかと思われます。また、この変更によるデメリットも見当りません。
パッチはdeferred:processの変更と、該当個所のテストの追加です。
議論/提案の場がないため、いきなり pull request しました。思想に合わない、あるいは私が何か勘違いをしている場合は気軽にリジェクトして下さい:-)
