### PR TITLE
deferred.elをMELPAにもアップロードしませんか？

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -79,6 +79,7 @@
   `(let ((it ,test))
      (if it ,(if rest `(deferred:aand ,@rest) 'it))))
 
+;;;###autoload
 (defmacro deferred:$ (&rest elements)
   "Anaphoric function chain macro for deferred chains."
   (declare (debug (&rest form)))


### PR DESCRIPTION
こんばんは ongaeshi と申します。

[ongaeshi/auto-shell-command](https://github.com/ongaeshi/auto-shell-command) というツールで deferred を使わせて頂いております。とても使いやすいライブラリですね。

deferredですが、MELPAにアップロードする予定はないでしょうか？
deferredに依存したツールをMELPAにアップロード出来るようになるので大変助かります。

[Add deferred · bcde2b0 · ongaeshi/melpa](https://github.com/ongaeshi/melpa/commit/bcde2b08a2b6a5c448222fdee45d4f39dffe8bde)

上記の修正を pull request して、MELPA側が取り込んでくれればインストール出来るようになります。githubの最新版を自動で取り込んでくれるためアップデートの手間もありません。

手元では上手くインストール出来ることを確認済みです。

最初のみ、 Version:、Package-Requires: 等のマジックコメントやautoloadマクロの埋め込み等をMELPA側から頼まれるかもしれないです。私が別のツールをアップロードした時は、autoloadマクロの埋め込みを指摘されました。

[Pull Request #118: duplicate-thing by ongaeshi · milkypostman/melpa](https://github.com/milkypostman/melpa/pull/118)

この pull request は `###autoload` マクロの埋め込み例です。

cc04132655dff50d936304735579620eca4da9cc

pull requestや動作確認など、私に出来ることがありましたらお手伝いしますのでよかったらご検討下さい。
