### PR TITLE
Set proper working directory for process

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -780,12 +780,13 @@ process."
         ((f f) (command command) (args args)
          (proc-name (format "*deferred:*%s*:%s" command uid))
          (buf-name (format " *deferred:*%s*:%s" command uid))
+         (pwd default-directory)
          (nd (deferred:new)) proc-buf proc)
       (deferred:nextc d
         (lambda (x)
           (setq proc-buf (get-buffer-create buf-name))
           (condition-case err
-              (progn
+              (let ((default-directory pwd))
                 (setq proc
                       (if (null (car args))
                           (apply f proc-name buf-name command nil)


### PR DESCRIPTION
Prior to this change,

``` cl
(let ((default-directory "/"))
  (deferred:nextc (deferred:process "pwd") 'message)
  (let ((default-directory "~/"))
    (dotimes (_ 3)
      (sleep-for 0.1))))
```

prints your $HOME instead of "/" because callbacks
are executed in context of sleep-for.  Now,
default-directory is properly propagated.

fixes #4
