### PR TITLE
Do not silence wrong-number-of-arguments

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -115,7 +115,12 @@
 The lambda function can define with zero and one argument."
   (condition-case err
       (funcall f arg)
-    ('wrong-number-of-arguments 
+    ('wrong-number-of-arguments
+     (display-warning 'deferred "\
+Callback that takes no argument may be specified.
+Passing callback with no argument is deprecated.
+Callback must take one argument.
+Or, this error is coming from somewhere inside of the callback: %S" err)
      (condition-case err2 
          (funcall f)
        ('wrong-number-of-arguments


### PR DESCRIPTION
`wrong-number-of-arguments` がどこから来ているかは分からないので、それを無視して再トライする今の実装はまずいんじゃないかと思います。 Callback で起こった `wrong-number-of-arguments` に気づくのが難しくなりますし、 callback に side-effect があるとデバッグが大変です。

後方互換性が無くなる変更なのでとりあえず warning をだしてみてはどうかと思ってPRしてみます。いつか callback は引数一つに固定出きると素晴らしいんじゃないかと思います。  引数を無視する関数は `(lambda (_) ...)` と書くことを推奨すると良いんじゃないでしょうか。
