### PR TITLE
Suggestion: handle errors using Emacs's structured form instead of strings

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -284,6 +284,7 @@ is a string, it is signaled as a generic error using `error'.
 Otherwise, ERR is formatted into a string as if by `print' before
 raising with `error'."
   (cond ((and (listp err)
+              (symbolp (car err))
               (get (car err) 'error-conditions))
          (signal (car err) (cdr err)))
         ((stringp err)


### PR DESCRIPTION
Hi,
I have been experimenting with emacs-deferred and emacs-epc and I find them useful. I would like to suggest a change to the way emacs-deferred handles errors so that it keeps all the original error information where possible, which is closer to Emacs's built-in condition handling.

Currently, emacs-deferred converts errors into a string using `(error-message-string)` before passing them along the chain of deferred objects. However, Emacs represents errors as a cons `(ERROR-SYMBOL . DATA)` so that structured data can be returned along with the exception. It seems simple and useful to keep all the original error information, as this patch implements. This will be especially useful if anyone wants to Emacs-EPC with an Emacs server process, to preserve full error information from conditions signaled in the remote Emacs.

Thanks for emacs-deferred!
- Change `deferred:default-errorback`: If the error is a cons of the
  form (ERROR-SYMBOL . DATA), re-raise it using (signal ...);
  otherwise convert to an error message using (error "%S" ...)
- Change `deferred:exec-task`: Pass errors unchanged to the next
  object in the queue instead of formatting with
  `error-message-string`. Call `deferred:default-errorback` if there
  is no callback and no next deferred object to handle an error at the
  end of the chain.
- Also remove `error-message-string` from `deferred:process-buffer-gen`
- Remove unneeded `default:esc-msg` function.
