### PR TITLE
Make `deferred:fail' return a deferred object in `error' state

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -419,7 +419,7 @@ an argument value for execution of the deferred task."
 (defun deferred:fail (&optional arg)
   "Create a synchronous deferred object."
   (let ((d (deferred:new)))
-    (deferred:exec-task d 'ok arg)
+    (deferred:exec-task d 'ng arg)
     d))
 
 (defun deferred:next (&optional callback arg)


### PR DESCRIPTION
I am not sure if I understand this correctly: `deferred:fail` has the same definition as `deferred:succeed`. Should it instead create a deferred object in error / `ng` state?
