### PR TITLE
Remove eval-when-compile for (require 'cl)

### DIFF
--- a/concurrent.el
+++ b/concurrent.el
@@ -32,8 +32,7 @@
 ;; - Dataflow
 ;; - Signal/Channel
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 (require 'deferred)
 
@@ -500,5 +499,10 @@ This function does nothing for the waiting deferred objects."
 
 
 (provide 'concurrent)
+
+;; Local Variables:
+;; byte-compile-warnings: (not cl-functions)
+;; End:
+
 ;;; concurrent.el ends here
 


### PR DESCRIPTION
Because `caddr` and `cdddr` are functions, not macros.
I think this problem causes 'https://github.com/tkf/emacs-jedi/issues/95'

Please see this patch.
