### PR TITLE
コマンドに%が含まれてコマンドの実行に失敗したときエラー出る

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -802,9 +802,9 @@ process."
                    (cond
                     ((string-match "exited abnormally" event)
                      (let ((msg (if (buffer-live-p proc-buf)
-                                    (deferred:buffer-string
-                                      (format "Process [%s] exited abnormally : %%s" 
-                                              command) proc-buf)
+                                    (format "Process [%s] exited abnormally : %s"
+                                            command
+                                            (with-current-buffer proc-buf (buffer-string)))
                                   (concat "Process exited abnormally: " proc-name))))
                        (kill-buffer proc-buf)
                        (deferred:post-task nd 'ng msg)))


### PR DESCRIPTION
以下のコードを実行すると，nextcerrorも呼ばれず，エラーが出ます．前提として，%sというファイルは存在しません．

``` lisp
(deferred:$
  (deferred:process-shell "cat %s")
  (deferred:nextc it
    (lambda (res)
      (message "success: %s" res)))
  (deferred:error it
    (lambda (res)
      (message "error: %s" res))))

; error in process sentinel: deferred:buffer-string: Not enough arguments for format string
; error in process sentinel: Not enough arguments for format string
```

コマンドに%が含まれるとき，formatしたあとに，%sなどが残ってしまうのが問題のようでした．
deferred:buffer-stringでformatする必要なさそうだったので，proc-bufの内容とcommandを使って一度でformatするよう変更しました．
テストの実行方法よくわからなかったのでテストは変更していません．実行もしていないので，テスト壊してしまったかもしれません．上記のコードで，errorが呼ばれることを確認しました．
