### PR TITLE
Remove eval-when-compile

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -65,8 +65,7 @@
 ;; This program makes simple multi-thread function, using
 ;; deferred.el.
 
-(eval-when-compile
-  (require 'cl))
+(require 'cl)
 
 (defvar deferred:version nil "deferred.el version")
 (setq deferred:version "0.3.2")


### PR DESCRIPTION
Because deferred.el uses cl functions such as `gensym`.
We should use `eval-when-compile` if the package uses only cl macros.
