### PR TITLE
Treat process-related variables in deferred.el

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -786,12 +786,16 @@ process."
          (proc-name (format "*deferred:*%s*:%s" command uid))
          (buf-name (format " *deferred:*%s*:%s" command uid))
          (pwd default-directory)
+         (env process-environment)
+         (con-type process-connection-type)
          (nd (deferred:new)) proc-buf proc)
       (deferred:nextc d
         (lambda (x)
           (setq proc-buf (get-buffer-create buf-name))
           (condition-case err
-              (let ((default-directory pwd))
+              (let ((default-directory pwd)
+                    (process-environment env)
+                    (process-connection-type con-type))
                 (setq proc
                       (if (null (car args))
                           (apply f proc-name buf-name command nil)


### PR DESCRIPTION
This makes process functions in deferred.el more compatible.

Note that there is a slight issue when using `process-environment`.  Since it is a list, it could be changed by a side-effect.  To even prevent that, we can do `(env (mapcar #'identity (copy-list process-environment)))`.  But I am not sure it should be in deferred.el.  Probably it should be up to user.
