### PR TITLE
Mprovements to url related functions

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -854,7 +854,8 @@ process."
      (defun deferred:url-retrieve (url &optional cbargs silent inhibit-cookies)
        "A wrapper function for url-retrieve. The next deferred
 object receives the buffer object that URL will load
-into. Currently dynamic binding variables are not supported."
+into. Values of dynamically bound 'url-request-data', 'url-request-method' and
+'url-request-extra-headers' are passed to url-retrieve call."
        (lexical-let ((nd (deferred:new)) (url url)
                      (cbargs cbargs) (silent silent) (inhibit-cookies inhibit-cookies) buf
                      (local-values (mapcar (lambda (symbol) (symbol-value symbol)) url-global-variables)))


### PR DESCRIPTION
This set of patches improves url-retrieve related set of functions.

Now dynamically bound variables (request method, headers, data) are preserved for url-retrieve call.
Also all params of url-retrieved are now supported by deferred:url-retrieve.

Please let me know if there are any problems with this pull request.

Thanks!
