### PR TITLE
'ret' should not be global variable

### DIFF
--- a/test-deferred.el
+++ b/test-deferred.el
@@ -359,11 +359,12 @@
   "> global onerror"
   (should= "ONERROR"
           ;; default onerror handler test
-          (let (ret (deferred:onerror
-                      (lambda (e) (setq ret (concat "ON" (error-message-string e))))))
-            (dtest
-             (next (error "ERROR")))
-            ret)))
+           (lexical-let (ret)
+             (let ((deferred:onerror
+                     (lambda (e) (setq ret (concat "ON" (error-message-string e))))))
+               (dtest
+                (next (error "ERROR")))
+               ret))))
 
 (ert-deftest deferred-async-call ()
   "> async call"


### PR DESCRIPTION
オリジナルのコードでは, `ret`がローカル変数でないので修正しました(未宣言の変数として
扱われる). スコープに関する問題だけだと, `let*`でよいですが, `deferred:onerror`は
クロージャであるべきと思われるので, `lexical-let`でラップしました.

ご確認のほどよろしくお願いします.
(元々テストは通っていますが, 意図した通りになっていないと思われます)
