### PR TITLE
Fix for unused value

### DIFF
--- a/concurrent.el
+++ b/concurrent.el
@@ -207,7 +207,7 @@ permission is returned, the task is executed."
       :catch
       error-func
       :finally
-      (lambda (x) (cc:semaphore-release semaphore)))))
+      (lambda (_x) (cc:semaphore-release semaphore)))))
 (put 'cc:semaphore-with 'lisp-indent-function 1)
 
 (defun cc:semaphore-release-all (semaphore)
@@ -375,7 +375,7 @@ CHANNEL is a channel object that sends signals of variable events. Observers can
     (cc:dataflow-connect
      df 'set
      (lambda (args)
-       (destructuring-bind (event (key)) args
+       (destructuring-bind (_event (key)) args
          (let* ((obj (cc:dataflow-get-object-for-value df key))
                 (value (and obj (cc:dataflow-value obj))))
            (when obj
@@ -485,7 +485,6 @@ This function does nothing for the waiting deferred objects."
   (append
    (loop for i in (cc:dataflow-list df)
          for key = (cc:dataflow-key i)
-         for val = (cc:dataflow-value i)
          if (cc:dataflow-undefine-p i) collect key)
    (deferred:aand
      (cc:dataflow-parent-environment df)

--- a/deferred.el
+++ b/deferred.el
@@ -85,7 +85,6 @@
   (declare (debug (&rest form)))
   `(let (it)
      ,@(loop for i in elements
-             with it = nil
              collect
              `(setq it ,i))
      it))
@@ -93,7 +92,7 @@
 (defmacro deferred:lambda (args &rest body)
   "Anaphoric lambda macro for self recursion."
   (declare (debug ("args" form &rest form)))
-  (let ((argsyms (loop for i in args collect (gensym))))
+  (let ((argsyms (loop repeat (length args) collect (gensym))))
   `(lambda (,@argsyms)
      (lexical-let (self)
        (setq self (lambda( ,@args ) ,@body))
@@ -133,7 +132,7 @@ Callback that takes no argument may be specified.
 Passing callback with no argument is deprecated.
 Callback must take one argument.
 Or, this error is coming from somewhere inside of the callback: %S" err)
-     (condition-case err2
+     (condition-case nil
          (funcall f)
        ('wrong-number-of-arguments
         (signal 'wrong-number-of-arguments (cdr err))))))) ; return the first error
@@ -170,7 +169,7 @@ Or, this error is coming from somewhere inside of the callback: %S" err)
       (lambda (e)
         (pp-display-expression e "*deferred:pp*")))
     (deferred:nextc it
-      (lambda (x) (pop-to-buffer "*deferred:pp*")))))
+      (lambda (_x) (pop-to-buffer "*deferred:pp*")))))
 
 (defvar deferred:debug-on-signal nil
 "If non nil, the value `debug-on-signal' is substituted this
@@ -519,14 +518,14 @@ idle for MSEC millisecond."
   "Call the given function asynchronously."
   (lexical-let ((f f) (args args))
     (deferred:next
-      (lambda (x)
+      (lambda (_x)
         (apply f args)))))
 
 (defun deferred:apply (f &optional args)
   "Call the given function asynchronously."
   (lexical-let ((f f) (args args))
     (deferred:next
-      (lambda (x)
+      (lambda (_x)
         (apply f args)))))
 
 
@@ -553,7 +552,7 @@ idle for MSEC millisecond."
                         (push ld items)
                         (setq ld
                               (lexical-let ((i i) (func func))
-                                (deferred:nextc ld (lambda (x) (deferred:call-lambda func i)))))
+                                (deferred:nextc ld (lambda (_x) (deferred:call-lambda func i)))))
                         finally return ld))
                  ((listp times-or-list)
                   (loop for i in times-or-list
@@ -562,7 +561,7 @@ idle for MSEC millisecond."
                         (push ld items)
                         (setq ld
                               (lexical-let ((i i) (func func))
-                                (deferred:nextc ld (lambda (x) (deferred:call-lambda func i)))))
+                                (deferred:nextc ld (lambda (_x) (deferred:call-lambda func i)))))
                         finally return ld)))))
       (setf (deferred-cancel rd)
             (lambda (x) (deferred:default-cancel x)
@@ -787,7 +786,7 @@ process."
                     (with-current-buffer buf (buffer-string))
                   (kill-buffer buf)))))
     (setf (deferred-cancel d)
-          (lambda (x)
+          (lambda (_x)
             (deferred:default-cancel d)
             (deferred:default-cancel pd)))
     d))
@@ -804,7 +803,7 @@ process."
          (con-type process-connection-type)
          (nd (deferred:new)) proc-buf proc)
       (deferred:nextc d
-        (lambda (x)
+        (lambda (_x)
           (setq proc-buf (get-buffer-create buf-name))
           (condition-case err
               (let ((default-directory pwd)
@@ -816,7 +815,7 @@ process."
                         (apply f proc-name buf-name command args)))
                 (set-process-sentinel
                  proc
-                 (lambda (proc event)
+                 (lambda (_proc event)
                    (cond
                     ((string-match "exited abnormally" event)
                      (let ((msg (if (buffer-live-p proc-buf)
@@ -874,17 +873,17 @@ into. Values of dynamically bound 'url-request-data', 'url-request-method' and
                      (cbargs cbargs) (silent silent) (inhibit-cookies inhibit-cookies) buf
                      (local-values (mapcar (lambda (symbol) (symbol-value symbol)) url-global-variables)))
          (deferred:next
-           (lambda (x)
+           (lambda (_x)
              (progv url-global-variables local-values
                (condition-case err
                    (setq buf
                          (url-retrieve
-                          url (lambda (xx) (deferred:post-task nd 'ok buf))
+                          url (lambda (_xx) (deferred:post-task nd 'ok buf))
                           cbargs silent inhibit-cookies))
                  (error (deferred:post-task nd 'ng err)))
              nil)))
          (setf (deferred-cancel nd)
-               (lambda (x)
+               (lambda (_x)
                  (when (buffer-live-p buf)
                    (kill-buffer buf))))
          nd))


### PR DESCRIPTION
- add prefix '_' for unused variable
- remove unused variable declaration

`deferred`を利用する他ライブラリで lexical-bindingを有効にした際, バイトコンパイル時に
未使用変数に関する警告が出るため修正しました. ご確認のほどよろしくお願いします.