### PR TITLE
deferred:version: bump to 0.5.0

### DIFF
--- a/deferred.el
+++ b/deferred.el
@@ -71,7 +71,7 @@
 (declare-function pp-display-expression 'pp)
 
 (defvar deferred:version nil "deferred.el version")
-(setq deferred:version "0.4.0")
+(setq deferred:version "0.5.0")
 
 ;;; Code:
 


### PR DESCRIPTION
To match the version-string at the top, and the tagged release.