### PR TITLE
Detect subprocess termination more robustly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis

--- a/deferred.el
+++ b/deferred.el
@@ -5,7 +5,7 @@
 ;; Author: SAKURAI Masashi <m.sakurai at kiwanami.net>
 ;; Version: 0.5.0
 ;; Keywords: deferred, async
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/kiwanami/emacs-deferred
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/deferred.el
+++ b/deferred.el
@@ -67,6 +67,7 @@
 ;; deferred.el.
 
 (require 'cl-lib)
+(require 'subr-x)
 
 (declare-function pp-display-expression 'pp)
 
@@ -807,25 +808,28 @@ the command process."
                         (apply f proc-name buf-name command args)))
                 (set-process-sentinel
                  proc
-                 (lambda (_proc event)
-                   (cond
-                    ((string-match "exited abnormally" event)
-                     (let ((msg (if (buffer-live-p proc-buf)
-                                    (format "Process [%s] exited abnormally : %s"
-                                            command
-                                            (with-current-buffer proc-buf (buffer-string)))
-                                  (concat "Process exited abnormally: " proc-name))))
-                       (kill-buffer proc-buf)
-                       (deferred:post-task nd 'ng msg)))
-                    ((equal event "finished\n")
-                     (deferred:post-task nd 'ok proc-buf)))))
-                (setf (deferred-cancel nd)
-                      (lambda (x) (deferred:default-cancel x)
-                        (when proc
-                          (kill-process proc)
-                          (kill-buffer proc-buf)))))
-            (error (deferred:post-task nd 'ng err)))
-          nil))
+                 (lambda (proc event)
+		   (unless (process-live-p proc)
+		     (if (zerop (process-exit-status proc))
+			 (deferred:post-task nd 'ok proc-buf)
+		       (let ((msg (format "Deferred process exited abnormally:\n  command: %s\n  exit status: %s %s\n  event: %s\n  buffer contents: %S"
+					  command
+					  (process-status proc)
+					  (process-exit-status proc)
+					  (string-trim-right event)
+					  (if (buffer-live-p proc-buf)
+					      (with-current-buffer proc-buf
+						(buffer-string))
+					    "(unavailable)"))))
+			 (kill-buffer proc-buf)
+			 (deferred:post-task nd 'ng msg))))))
+		(setf (deferred-cancel nd)
+		      (lambda (x) (deferred:default-cancel x)
+			(when proc
+			  (kill-process proc)
+			  (kill-buffer proc-buf)))))
+	    (error (deferred:post-task nd 'ng err)))
+	  nil))
       nd)))
 
 (defmacro deferred:processc (d command &rest args)


### PR DESCRIPTION
Looking at the text of the event string provided to the process sentinel is brittle.  We cannot really anticipate the many different values this might have, and therefore cannot anticipate how to respond to all of them.  For example, if the subprocess crashes due to a SIGSEGV, then the event text might read `segmentation fault (core dumped)`.  The preexisting sentintel code did not check for this specific string, and therefore would never realize that the subprocess had terminated.

The new approach uses Emacs process management functions like `(process-live-p ...)`, `(process-status ...)`, and `(process-exit-status ...)`.  These let us determine the process’s current status much more precisely, with more detailed information about how/why it terminated.